### PR TITLE
Add timestamp adjuster parameter to compensate for GStreamer delay in capturing frames

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Note that GStreamer is licensed under the LGPL, and GStreamer plugins have their
 * `use_gst_timestamps`: Use the GStreamer buffer timestamps for the image message header timestamps (setting this to `false` results in header timestamps being the time that the image buffer transfer is completed)
 * `image_encoding`: image encoding ("rgb8", "mono8", "yuv422", "jpeg")
 * `use_sensor_data_qos`: The flag to use sensor data qos for camera topic(image, camera_info)
-* `acquisition_offset`: Time offset (in seconds) between camera acquisition and gst_timestamp. Effective only with `use_gst_timestamps` set to `true`.
+* `acquisition_offset`: Time offset (in nanoseconds) between camera acquisition and gst_timestamp. Effective only with `use_gst_timestamps` set to `true`.
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Note that GStreamer is licensed under the LGPL, and GStreamer plugins have their
 * `use_gst_timestamps`: Use the GStreamer buffer timestamps for the image message header timestamps (setting this to `false` results in header timestamps being the time that the image buffer transfer is completed)
 * `image_encoding`: image encoding ("rgb8", "mono8", "yuv422", "jpeg")
 * `use_sensor_data_qos`: The flag to use sensor data qos for camera topic(image, camera_info)
+* `acquisition_offset`: Time offset (in seconds) between camera acquisition and gst_timestamp. Effective only with `use_gst_timestamps` set to `true`.
 
 ## Examples
 

--- a/include/gscam/gscam.hpp
+++ b/include/gscam/gscam.hpp
@@ -75,7 +75,7 @@ private:
   // Calibration between ros::Time and gst timestamps
   uint64_t time_offset_;
   // Calibration between gst_timestamps and camera shutter timestamps
-  uint64_t acquisition_offset_;
+  int64_t acquisition_offset_;
   camera_info_manager::CameraInfoManager camera_info_manager_;
   image_transport::CameraPublisher camera_pub_;
   // Case of a jpeg only publisher

--- a/include/gscam/gscam.hpp
+++ b/include/gscam/gscam.hpp
@@ -74,6 +74,8 @@ private:
   // ROS Inteface
   // Calibration between ros::Time and gst timestamps
   uint64_t time_offset_;
+  // Calibration between gst_timestamps and camera shutter timestamps
+  uint64_t acquisition_offset_;
   camera_info_manager::CameraInfoManager camera_info_manager_;
   image_transport::CameraPublisher camera_pub_;
   // Case of a jpeg only publisher

--- a/src/gscam.cpp
+++ b/src/gscam.cpp
@@ -139,7 +139,7 @@ bool GSCam::configure()
   // Get acquisition and gst timestamp offset
   auto param_desc = rcl_interfaces::msg::ParameterDescriptor{};
   param_desc.description = "Time offset [seconds] between gst_timestamps and camera shutter.";
-  acquisition_offset_ = 1000000000UL * declare_parameter<double>("acquisition_offset", 0.0, param_desc);
+  acquisition_offset_ = declare_parameter<int64_t>("acquisition_offset", 0, param_desc);
 
   return true;
 }

--- a/src/gscam.cpp
+++ b/src/gscam.cpp
@@ -136,6 +136,11 @@ bool GSCam::configure()
 
   use_sensor_data_qos_ = declare_parameter("use_sensor_data_qos", false);
 
+  // Get acquisition and gst timestamp offset
+  auto param_desc = rcl_interfaces::msg::ParameterDescriptor{};
+  param_desc.description = "Time offset [seconds] between gst_timestamps and camera shutter.";
+  acquisition_offset_ = 1000000000UL * declare_parameter<double>("acquisition_offset", 0.0, param_desc);
+
   return true;
 }
 
@@ -353,7 +358,7 @@ void GSCam::publish_stream()
     sensor_msgs::msg::CameraInfo::SharedPtr cinfo;
     cinfo.reset(new sensor_msgs::msg::CameraInfo(cur_cinfo));
     if (use_gst_timestamps_) {
-      cinfo->header.stamp = rclcpp::Time(GST_TIME_AS_NSECONDS(buf->pts + bt) + time_offset_);
+      cinfo->header.stamp = rclcpp::Time(GST_TIME_AS_NSECONDS(buf->pts + bt) + time_offset_ - acquisition_offset_);
     } else {
       cinfo->header.stamp = now();
     }

--- a/src/gscam.cpp
+++ b/src/gscam.cpp
@@ -358,7 +358,8 @@ void GSCam::publish_stream()
     sensor_msgs::msg::CameraInfo::SharedPtr cinfo;
     cinfo.reset(new sensor_msgs::msg::CameraInfo(cur_cinfo));
     if (use_gst_timestamps_) {
-      cinfo->header.stamp = rclcpp::Time(GST_TIME_AS_NSECONDS(buf->pts + bt) + time_offset_ - acquisition_offset_);
+      cinfo->header.stamp = rclcpp::Time(
+        GST_TIME_AS_NSECONDS(buf->pts + bt) + time_offset_ - acquisition_offset_);
     } else {
       cinfo->header.stamp = now();
     }


### PR DESCRIPTION
This PR adds a new parameter `acquisition_offset` which represent the amount of nanosecond between actual camera acquisition of the frame and frame availability on the GStreamer pipeline.

A positive value is expected but not enforced yet in this version.