### PR TITLE
feat: add diagnostic rate monitor for camera publisher

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,8 @@ find_package(image_transport REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_components REQUIRED)
 find_package(sensor_msgs REQUIRED)
+find_package(std_msgs REQUIRED)
+find_package(diagnostic_updater REQUIRED)
 find_package(camera_calibration_parsers REQUIRED)
 find_package(camera_info_manager REQUIRED)
 
@@ -33,6 +35,8 @@ ament_target_dependencies(gscam
   "rclcpp"
   "rclcpp_components"
   "sensor_msgs"
+  "std_msgs"
+  "diagnostic_updater"
   "camera_calibration_parsers"
   "camera_info_manager")
 

--- a/include/gscam/gscam.hpp
+++ b/include/gscam/gscam.hpp
@@ -74,6 +74,9 @@ private:
   std::string camera_info_url_;
   bool use_sensor_data_qos_;
 
+  double camera_expected_min_fps_;
+  double camera_expected_max_fps_;
+
   // ROS Inteface
   // Calibration between ros::Time and gst timestamps
   uint64_t time_offset_;
@@ -91,8 +94,8 @@ private:
 
   // Diagnostics
   diagnostic_updater::Updater diag_updater_;
-  double diag_min_freq_{1.0};
-  double diag_max_freq_{120.0};
+  double diag_min_freq_;
+  double diag_max_freq_;
   std::unique_ptr<diagnostic_updater::TopicDiagnostic> img_freq_diag_;
 
   // Poll gstreamer on a separate thread

--- a/include/gscam/gscam.hpp
+++ b/include/gscam/gscam.hpp
@@ -32,6 +32,9 @@ extern "C" {
 #include "sensor_msgs/msg/compressed_image.hpp"
 #include "sensor_msgs/msg/camera_info.hpp"
 #include "sensor_msgs/srv/set_camera_info.hpp"
+#include "std_msgs/msg/header.hpp"
+#include "diagnostic_updater/diagnostic_updater.hpp"
+#include "diagnostic_updater/publisher.hpp"
 
 namespace gscam
 {
@@ -81,6 +84,16 @@ private:
   // Case of a jpeg only publisher
   rclcpp::Publisher<sensor_msgs::msg::CompressedImage>::SharedPtr jpeg_pub_;
   rclcpp::Publisher<sensor_msgs::msg::CameraInfo>::SharedPtr cinfo_pub_;
+
+  // Heartbeat
+  rclcpp::Publisher<std_msgs::msg::Header>::SharedPtr heartbeat_pub_;
+  rclcpp::TimerBase::SharedPtr heartbeat_timer_;
+
+  // Diagnostics
+  diagnostic_updater::Updater diag_updater_;
+  double diag_min_freq_{1.0};
+  double diag_max_freq_{120.0};
+  std::unique_ptr<diagnostic_updater::TopicDiagnostic> img_freq_diag_;
 
   // Poll gstreamer on a separate thread
   std::thread pipeline_thread_;

--- a/include/gscam/gscam.hpp
+++ b/include/gscam/gscam.hpp
@@ -74,9 +74,6 @@ private:
   std::string camera_info_url_;
   bool use_sensor_data_qos_;
 
-  double camera_expected_min_fps_;
-  double camera_expected_max_fps_;
-
   // ROS Inteface
   // Calibration between ros::Time and gst timestamps
   uint64_t time_offset_;

--- a/package.xml
+++ b/package.xml
@@ -26,6 +26,8 @@
   <depend>rclcpp_components</depend>
   <depend>image_transport</depend>
   <depend>sensor_msgs</depend>
+  <depend>std_msgs</depend>
+  <depend>diagnostic_updater</depend>
   <depend>camera_calibration_parsers</depend>
   <depend>camera_info_manager</depend>
 

--- a/src/gscam.cpp
+++ b/src/gscam.cpp
@@ -106,6 +106,9 @@ bool GSCam::configure()
   camera_info_url_ = declare_parameter("camera_info_url", "");
   camera_name_ = declare_parameter("camera_name", "");
 
+  diag_min_freq_ = declare_parameter("camera_expected_min_fps", 13.0);
+  diag_max_freq_ = declare_parameter("camera_expected_max_fps", 17.0);
+
   // Get the image encoding
   image_encoding_ =
     declare_parameter("image_encoding", std::string(sensor_msgs::image_encodings::RGB8));

--- a/src/gscam.cpp
+++ b/src/gscam.cpp
@@ -108,6 +108,7 @@ bool GSCam::configure()
 
   diag_min_freq_ = declare_parameter("camera_expected_min_fps", 13.0);
   diag_max_freq_ = declare_parameter("camera_expected_max_fps", 17.0);
+  diag_updater_.setHardwareID(declare_parameter("hardware_id", "unknown"));
 
   // Get the image encoding
   image_encoding_ =

--- a/src/gscam.cpp
+++ b/src/gscam.cpp
@@ -31,6 +31,7 @@ extern "C" {
 #include "sensor_msgs/msg/compressed_image.hpp"
 #include "sensor_msgs/msg/camera_info.hpp"
 #include "sensor_msgs/image_encodings.hpp"
+#include "std_msgs/msg/header.hpp"
 
 #include "gscam/gscam.hpp"
 
@@ -43,7 +44,8 @@ GSCam::GSCam(const rclcpp::NodeOptions & options)
   pipeline_(NULL),
   sink_(NULL),
   camera_info_manager_(this),
-  stop_signal_(false)
+  stop_signal_(false),
+  diag_updater_(this)
 {
   pipeline_thread_ = std::thread(
     [this]()
@@ -266,6 +268,22 @@ bool GSCam::init_stream()
       this, "camera/image_raw", qos.get_rmw_qos_profile());
   }
 
+  // Heartbeat
+  heartbeat_pub_ = create_publisher<std_msgs::msg::Header>("~/heartbeat", rclcpp::QoS{1});
+  heartbeat_timer_ = create_wall_timer(
+    std::chrono::seconds(1),
+    [this]() {
+      std_msgs::msg::Header msg;
+      msg.stamp = now();
+      msg.frame_id = frame_id_;
+      heartbeat_pub_->publish(msg);
+    });
+
+  // Diagnostics
+  diagnostic_updater::FrequencyStatusParam freq_params{&diag_min_freq_, &diag_max_freq_};
+  img_freq_diag_ = std::make_unique<diagnostic_updater::TopicDiagnostic>(
+    "Image pub rate", diag_updater_, freq_params, diagnostic_updater::DefaultTimeStampStatusParam);
+
   return true;
 }
 
@@ -412,6 +430,8 @@ void GSCam::publish_stream()
       // Publish the image/info
       camera_pub_.publish(img, cinfo);
     }
+
+    img_freq_diag_->tick(cinfo->header.stamp);
 
     // Release the buffer
     if (buf) {


### PR DESCRIPTION
<img width="560" height="507" alt="image" src="https://github.com/user-attachments/assets/21968533-bc98-4290-8b87-af19ffe1500c" />


hardware_id, min and max freq are configurable via ROS 2 parameters.
This lets us monitor diagnostics to know if camera is publishing instead of checking the actual camera (computationally heavy)

branch is being tested in: https://github.com/ArchangelAutonomy/prod-xnaut-drivers/pull/245